### PR TITLE
sysparam_query fix and documentation for creating new record/ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,37 @@ Snow.post({
 );
 ```
 
+##### Create a new servicenow ticket
+Create records using the variables set from the setTable (**DO NOT** setQuery) method (example shown below). This will create a new record and return the detials of the new record.
+```Javascript
+Snow.post(JSONbody[object], callback)
+```
+Code Example:
+```Javascript
+
+Snow.setTable('incident'); //setting the up the table variable (the table where you want to add/create a record) 
+
+Snow.post({
+    opened_by: 'System Administrator',  //example servicenow field BEGIN
+    user_input: '',                     //...
+    sys_domain: 'global',               //....
+    state: 'New',                       //.....
+    sys_created_by: 'admin',            //......
+    knowledge: 'false',                 //.......
+    sysparm_query: this.query,          //........ 
+    short_description: 'some short description', //.
+    caller_id: 'CALLER_ID',             //...........
+    active: true,                       //example servicenow field END
+    sysparm_action: 'insert'            //THIS IS THE IMPORTANT BIT!! This defines that a new record has to be created
+    
+}, (err, res) => {
+    // Do stuff with updated records.
+    console.log(res);                   //prints the newly created ticket or record in your git bash or terminal
+    }
+);
+```
+
+
 #### 3. RITM Methods (Class: Snow.Ritm)
 
 ##### getRitms

--- a/service-now.js
+++ b/service-now.js
@@ -107,7 +107,8 @@ class ServiceNow {
             auth: this.auth,
             qs: {
                 JSONv2: '',
-                sysparm_query: this.query,
+                //sysparm_query: this.query, --> this did'nt quite work for me, give me an error stating that 'sysparam_query cannot be null/empty',  so I replaced it with the following code:
+                sysparm_query: this.qs.sysparm_query, //this works perfectly now
                 displayvariables: 'true',
                 displayvalues: 'true',
                 sysparm_action: 'update'


### PR DESCRIPTION
### sysparam_query cannot be null/empty fix (service-now.js)
First of all, **awesome work @eliash91 **! I've just made some very minor changes..
Ran into an issue while trying to update a servicenow ticket (in my case 'incident'). 
Kept getting an error response that 'sysparam_query cannot be null/empty' (am paraphrasing). 

So made a minor adjustment to line number 110 (file: service-now.js). Changed it to `sysparm_query: this.qs.sysparm_query` and that works perfectly for me. 

### added some documentation for creating a new record
Was trying to create a new record using this package but couldn't find the documentation for it. So have added some documentation for creating a new record here now.
**Thanks once again for this node package @eliash91 **